### PR TITLE
chore: obsolete the concept of extended filters

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,12 +48,12 @@ Without special reasons for grouping filters, new filters should be appended to 
 
 ```adblock
 !! DO
-! https://lnk/to/reference
+! https://link/to/reference
 domain.tld##filter$old
 domain.tld##filter$new
 
 !! DO NOT
-! https://lnk/to/reference
+! https://link/to/reference
 domain.tld##filter$new
 domain.tld##filter$old
 ```
@@ -65,18 +65,17 @@ In most cases, you should not use generic filters.
 
 ```adblock
 !! DO
-! https://lnk/to/reference
+! https://link/to/reference
 domain.tld##element
 
 !! DO NOT
-! https://lnk/to/reference
+! https://link/to/reference
 ##element
 ```
 
-### SHOULD avoid complex filters
+### SHOULD prioritize Manifest V3 compatible filters
 
-Complex filters mean that they're not working on Manifest V3.
-We'll prioritize Manifest V3 filters over Manifest V2 filters for compatibility and performance.
-If you can solve the problem with Manifest V3 compatible filter, you should use Manifest V3 filter instead of Manifest V2 filter.
+Some filters may not compatible with Manifest V3.
+You should prioritize Manifest V3 compatible format over Manifest V2 only filter if available.
 
 Also, see [Ghostery adblocker engine compatibility matrix](https://github.com/ghostery/adblocker/wiki/Compatibility-Matrix).

--- a/assets/index.html
+++ b/assets/index.html
@@ -19,11 +19,7 @@
   <p>Ghostery filter lists are available on <a href="https://github.com/ghostery/broken-page-reports">@GitHub/Ghostery/broken-page-reports</a>.</p>
   <ul>
     <li>
-      <p>Compiled filters</p>
-      <ul>
-        <li><a href="./filters.txt">Ghostery filters</a></li>
-        <li><a href="./filters-extended.txt">Ghostery filters (extended, mv2)</a></li>
-      </ul>
+      <p><a href="./filters.txt">Ghostery filters</a></p>
     </li>
     <li>
       <p>Individual filters</p>

--- a/src/build.js
+++ b/src/build.js
@@ -10,7 +10,7 @@ const now = Date.now();
 
 const headerLines = `[Adblock Plus 2.0]
 ! Homepage: https://github.com/ghostery/broken-page-reports
-! Title: {{title}}
+! Title: @Ghostery filters
 ! Expires: 1 day
 ! Version: ${now}
 `;
@@ -54,13 +54,9 @@ const main = () => {
 	createDirectory(env.outDir);
 	createDirectory(path.join(env.outDir, 'filters'));
 
-	const outFiles = {
-		standard: path.join(env.outDir, 'filters.txt'),
-		extended: path.join(env.outDir, 'filters-extended.txt'),
-	};
+	const outFile = path.join(env.outDir, 'filters.txt');
 
-	writeFileSync(outFiles.standard, headerLines.replace('{{title}}', '@Ghostery filters'), 'utf8');
-	writeFileSync(outFiles.extended, headerLines.replace('{{title}}', '@Ghostery filters — extended'), 'utf8');
+	writeFileSync(outFile, headerLines, 'utf8');
 
 	copyFileSync(path.join(cwd, 'assets/index.html'), path.join(env.outDir, 'index.html'));
 
@@ -70,12 +66,6 @@ const main = () => {
 
 	for (const file of files) {
 		const {header, body} = parseFilter(readFileSync(path.join(root, file), 'utf8'));
-
-		let outFile = outFiles.standard;
-
-		if (file.includes('-extended')) {
-			outFile = outFiles.extended;
-		}
 
 		appendFileSync(outFile, body, 'utf8');
 		writeFileSync(path.join(env.outDir, 'filters', file), header.replace('{{version}}', now) + '\n' + body, 'utf8');


### PR DESCRIPTION
The extended filters were originally intended to exclude MV3 incompatible filters from the filter list. However, I found that the responsibility and role of filter exclusion is in ad-blocker after the discussion. So I'm removing this concept from this repository.