### PR TITLE
Fixed the exclusion rule fof the gdpr overlay

### DIFF
--- a/filters/autoconsent-compatibility.txt
+++ b/filters/autoconsent-compatibility.txt
@@ -700,7 +700,7 @@ tibber.com#@#div[class*="CookieConsent"]
 #@#.cc-overlay-wrapper
 #@#.cc-theme-classic.cc-window
 #@##pandectes-banner
-#@#gdpr-blocking-page-overlay
+#@##gdpr-blocking-page-overlay
 #@#div.cc-revoke
 ! >>> url=https://pandectes.myshopify.com/cdn/shopifycloud/consent-tracking-api/v0.1/consent-tracking-api.js
 ! ... source=https://pandectes.myshopify.com/


### PR DESCRIPTION
Noticed that my original exclusion rule in https://github.com/ghostery/broken-page-reports/commit/0a43ecb7ce06376313ca4ec25e72a733dc0fee77 was wrong (forgot the extra "#").

refs https://github.com/ghostery/broken-page-reports/issues/650