### PR TITLE
fix: nytimes.com

### DIFF
--- a/filters/fixes.txt
+++ b/filters/fixes.txt
@@ -1036,3 +1036,6 @@ app.viralsweep.com#@#.promotion
 
 ! https://github.com/ghostery/broken-page-reports/issues/907
 bankerandtradesman.com##article:style(display: block !important)
+
+! https://github.com/ghostery/broken-page-reports/issues/924
+nytimes.com#@##complianceOverlay


### PR DESCRIPTION
fixes https://github.com/ghostery/broken-page-reports/issues/924