### PR TITLE
Fix: consent.google.com

### DIFF
--- a/filters/autoconsent-compatibility.txt
+++ b/filters/autoconsent-compatibility.txt
@@ -836,3 +836,7 @@ skandia.se#@#.CookieBanner
 
 ! https://github.com/ghostery/broken-page-reports/issues/1000
 citibank.pl#@#.CookieStyle
+
+! https://github.com/uBlockOrigin/uAssets/blob/1411b1e79452142eea8249c6d522e8ebc9547f47/filters/annoyances-cookies.txt#L51C1-L53C76
+consent.google.*#@#+js(trusted-click-element, form[action] button[jsname="tWT92d"])
+consent.google.*#@#[data-p*="/consent.google."]:has(button[jsname="tWT92d"])


### PR DESCRIPTION
Cosmetic filters were preventing Never-Consent to work.