### PR TITLE
fix(cookie): usatoday.com

### DIFF
--- a/filters/cookies.txt
+++ b/filters/cookies.txt
@@ -284,6 +284,10 @@ new.nortic.se##+js(set-cookie, nortic-cookies-consent, true)
 ! ... source=https://usatoday.com/
 ! ... type=xhr
 ||gigkarma.com^
+! >>> url=https://sayinnovation.com/a
+! ... source=https://usatoday.com/
+! ... type=xhr
+||sayinnovation.com^
 
 ! https://github.com/ghostery/broken-page-reports/issues/264
 fxhome.com##[class^="style_cookiesContainer"]


### PR DESCRIPTION
fixes https://github.com/ghostery/broken-page-reports/issues/743

```
||sayinnovation.com^
```