### PR TITLE
fix(filters): Jan 9

### DIFF
--- a/filters/cookies.txt
+++ b/filters/cookies.txt
@@ -355,3 +355,16 @@ bestbuy.ca###onetrust-consent-sdk
 
 ! https://github.com/ghostery/broken-page-reports/issues/1053
 coastcapitalsavings.com##div.cookies-disclaimer
+
+! https://github.com/ghostery/broken-page-reports/issues/1060
+! >>> url=https://sdk.privacy-center.org/sdk/326c6bd191c11b5e1333a693feb3a6027adc6492/modern/sdk.326c6bd191c11b5e1333a693feb3a6027adc6492.js
+! ... source=https://cinema-series.orange.fr/series/toutes-les-actus/une-fille-m-a-tout-a-coup-traite-de-l-interprete-de-nellie-oleson-la-petite-maison-dans-la-prairie-etait-prise-a-partie-par-le-public-de-la-serie-CNT000002gSIq2.html
+! ... type=script
+@@||sdk.privacy-center.org^$script,domain=orange.fr
+! >>> url=https://tags.tiqcdn.com/utag/orange/dnu/prod/utag.440.js?utv=ut4.39.202408060909
+! ... source=https://cinema-series.orange.fr/series/toutes-les-actus/une-fille-m-a-tout-a-coup-traite-de-l-interprete-de-nellie-oleson-la-petite-maison-dans-la-prairie-etait-prise-a-partie-par-le-public-de-la-serie-CNT000002gSIq2.html
+! ... type=script
+@@||tags.tiqcdn.com/utag/orange/dnu/prod$script,domain=orange.fr
+orange.fr##+js(set, consent, {})
+orange.fr##+js(trusted-set, consent.dmpublic, '{"value":"optin"}')
+orange.fr##+js(set, consent.digiteka, 1)

--- a/filters/cookies.txt
+++ b/filters/cookies.txt
@@ -180,11 +180,6 @@ tgcom24.mediaset.it###rti-privacy-banner-id
 ! ... type=script
 ||consentmanager.net^$important,domain=nordbayern.de|next-mobility.de|morgenpost.de|derwesten.de|interspar.at|azerty.nl|l-iz.de|portalsamorzadowy.pl|dev-insider.de|reiseland-brandenburg.de
 
-! A temporal cosmetic fix for privacy-mgmt.com
-! autoconsent rule update is required to fix this
-heute.at##[id^="sp_message_container_"]
-heute.at##body[style^="overflow"]:style(overflow: auto !important)
-
 ! https://github.com/ghostery/broken-page-reports/issues/691
 ! >>> url=https://polityka-prywatnosci.tvp.pl/shared/consent_api.php?consent=getPublicVendorList&consentApiVersion=v2
 ! ... source=https://tvpworld.com/
@@ -350,10 +345,13 @@ bestbuy.ca###onetrust-consent-sdk
 ! https://github.com/ghostery/broken-page-reports/issues/1053
 coastcapitalsavings.com##div.cookies-disclaimer
 
+! https://github.com/ghostery/broken-page-reports/issues/684
 ! https://github.com/ghostery/broken-page-reports/issues/151
 ! https://github.com/ghostery/broken-page-reports/issues/172
 derstandard.at##body[data-pur]>[id^="sp_message_container_"]
-lvz.de##[id^="sp_message_container_"]
+heute.at,lvz.de,chip.de##[id^="sp_message_container_"]
+lvz.de,chip.de,derstandard.at##html.sp-message-open>body:style(overflow: auto !important)
+heute.at##body[style^="overflow"]:style(overflow: auto !important)
 
 ! https://github.com/ghostery/broken-page-reports/issues/1060
 ! >>> url=https://sdk.privacy-center.org/sdk/326c6bd191c11b5e1333a693feb3a6027adc6492/modern/sdk.326c6bd191c11b5e1333a693feb3a6027adc6492.js

--- a/filters/cookies.txt
+++ b/filters/cookies.txt
@@ -339,14 +339,8 @@ sat1.de##cmp-banner
 ! https://github.com/ghostery/broken-page-reports/issues/318
 ohga.it##.gdpr-modal
 
-! https://github.com/ghostery/broken-page-reports/issues/151
-derstandard.at##body[data-pur]>[id^="sp_message_container_"]
-
 ! https://github.com/ghostery/broken-page-reports/issues/166
 combi.de##.modal--cookie-notice.open
-
-! https://github.com/ghostery/broken-page-reports/issues/172
-lvz.de##[id^="sp_message_container_"]
 
 ! https://github.com/ghostery/broken-page-reports/issues/1051
 !#if env_firefox
@@ -355,6 +349,11 @@ bestbuy.ca###onetrust-consent-sdk
 
 ! https://github.com/ghostery/broken-page-reports/issues/1053
 coastcapitalsavings.com##div.cookies-disclaimer
+
+! https://github.com/ghostery/broken-page-reports/issues/151
+! https://github.com/ghostery/broken-page-reports/issues/172
+derstandard.at##body[data-pur]>[id^="sp_message_container_"]
+lvz.de##[id^="sp_message_container_"]
 
 ! https://github.com/ghostery/broken-page-reports/issues/1060
 ! >>> url=https://sdk.privacy-center.org/sdk/326c6bd191c11b5e1333a693feb3a6027adc6492/modern/sdk.326c6bd191c11b5e1333a693feb3a6027adc6492.js

--- a/filters/fixes.txt
+++ b/filters/fixes.txt
@@ -1103,19 +1103,6 @@ citibank.pl##.CookieStyle
 ! https://github.com/ghostery/broken-page-reports/issues/1022
 filen.io#@#.z-50
 
-! https://github.com/ghostery/broken-page-reports/issues/1060
-! >>> url=https://sdk.privacy-center.org/sdk/326c6bd191c11b5e1333a693feb3a6027adc6492/modern/sdk.326c6bd191c11b5e1333a693feb3a6027adc6492.js
-! ... source=https://cinema-series.orange.fr/series/toutes-les-actus/une-fille-m-a-tout-a-coup-traite-de-l-interprete-de-nellie-oleson-la-petite-maison-dans-la-prairie-etait-prise-a-partie-par-le-public-de-la-serie-CNT000002gSIq2.html
-! ... type=script
-@@||sdk.privacy-center.org^$script,domain=orange.fr
-! >>> url=https://tags.tiqcdn.com/utag/orange/dnu/prod/utag.440.js?utv=ut4.39.202408060909
-! ... source=https://cinema-series.orange.fr/series/toutes-les-actus/une-fille-m-a-tout-a-coup-traite-de-l-interprete-de-nellie-oleson-la-petite-maison-dans-la-prairie-etait-prise-a-partie-par-le-public-de-la-serie-CNT000002gSIq2.html
-! ... type=script
-@@||tags.tiqcdn.com/utag/orange/dnu/prod$script,domain=orange.fr
-orange.fr##+js(set, consent, {})
-orange.fr##+js(trusted-set, consent.dmpublic, '{"value":"optin"}')
-orange.fr##+js(set, consent.digiteka, 1)
-
 ! https://github.com/ghostery/broken-page-reports/issues/877
 ! https://github.com/ghostery/broken-page-reports/issues/1061
 !#if env_experimental

--- a/filters/fixes.txt
+++ b/filters/fixes.txt
@@ -1115,3 +1115,10 @@ filen.io#@#.z-50
 orange.fr##+js(set, consent, {})
 orange.fr##+js(trusted-set, consent.dmpublic, '{"value":"optin"}')
 orange.fr##+js(set, consent.digiteka, 1)
+
+! https://github.com/ghostery/broken-page-reports/issues/877
+dogdrip.net##+js(trusted-suppress-native-method, confirm, '"애드블록"', abort)
+dogdrip.net##+js(trusted-suppress-native-method, confirm, '"adblocker"', abort)
+dogdrip.net##+js(trusted-suppress-native-method, document.querySelectorAll, '"link"', prevent)
+dogdrip.net##+js(trusted-suppress-native-method, document.querySelectorAll, '"style"', prevent)
+dogdrip.net##+js(trusted-suppress-native-method, String.prototype.concat, '"css-load.com"|"undefined"', abort)

--- a/filters/fixes.txt
+++ b/filters/fixes.txt
@@ -1117,8 +1117,10 @@ orange.fr##+js(trusted-set, consent.dmpublic, '{"value":"optin"}')
 orange.fr##+js(set, consent.digiteka, 1)
 
 ! https://github.com/ghostery/broken-page-reports/issues/877
-dogdrip.net##+js(trusted-suppress-native-method, confirm, '"애드블록"', abort)
-dogdrip.net##+js(trusted-suppress-native-method, confirm, '"adblocker"', abort)
-dogdrip.net##+js(trusted-suppress-native-method, document.querySelectorAll, '"link"', prevent)
-dogdrip.net##+js(trusted-suppress-native-method, document.querySelectorAll, '"style"', prevent)
-dogdrip.net##+js(trusted-suppress-native-method, String.prototype.concat, '"css-load.com"|"undefined"', abort)
+! https://github.com/ghostery/broken-page-reports/issues/1061
+dogdrip.net,tvtv.us##+js(trusted-suppress-native-method, confirm, '"애드블록"', abort)
+dogdrip.net,tvtv.us##+js(trusted-suppress-native-method, confirm, '"adblocker"', abort)
+dogdrip.net##+js(trusted-suppress-native-method, document.querySelectorAll, '"link"', abort)
+dogdrip.net##+js(trusted-suppress-native-method, document.querySelectorAll, '"style"', abort)
+dogdrip.net##+js(trusted-suppress-native-method, String.prototype.concat, '"/^css-load.com$/"|"undefined"', abort)
+tvtv.us##+js(trusted-suppress-native-method, String.prototype.concat, '"/^html-load.com$/"|"undefined"', abort)

--- a/filters/fixes.txt
+++ b/filters/fixes.txt
@@ -1118,7 +1118,7 @@ orange.fr##+js(set, consent.digiteka, 1)
 
 ! https://github.com/ghostery/broken-page-reports/issues/877
 ! https://github.com/ghostery/broken-page-reports/issues/1061
-!#if env_chromium || env_firefox
+!#if env_experimental
 dogdrip.net,tvtv.us##+js(trusted-suppress-native-method, confirm, '"애드블록"', abort)
 dogdrip.net,tvtv.us##+js(trusted-suppress-native-method, confirm, '"adblocker"', abort)
 dogdrip.net##+js(trusted-suppress-native-method, document.querySelectorAll, '"link"', abort)

--- a/filters/fixes.txt
+++ b/filters/fixes.txt
@@ -1118,6 +1118,7 @@ orange.fr##+js(set, consent.digiteka, 1)
 
 ! https://github.com/ghostery/broken-page-reports/issues/877
 ! https://github.com/ghostery/broken-page-reports/issues/1061
+!#if env_chromium || env_firefox
 dogdrip.net,tvtv.us##+js(trusted-suppress-native-method, confirm, '"애드블록"', abort)
 dogdrip.net,tvtv.us##+js(trusted-suppress-native-method, confirm, '"adblocker"', abort)
 dogdrip.net##+js(trusted-suppress-native-method, document.querySelectorAll, '"link"', abort)
@@ -1127,3 +1128,4 @@ dogdrip.net##+js(trusted-suppress-native-method, document.querySelectorAll, '"st
 ! Potential behavioral difference on scriptlet arguments: '/x$/' will escape $ but '"/x$/"' won't
 dogdrip.net##+js(trusted-suppress-native-method, String.prototype.concat, '"/^css-load.com$/"|"undefined"', abort)
 tvtv.us##+js(trusted-suppress-native-method, String.prototype.concat, '"/^html-load.com$/"|"undefined"', abort)
+!#endif

--- a/filters/fixes.txt
+++ b/filters/fixes.txt
@@ -1122,5 +1122,8 @@ dogdrip.net,tvtv.us##+js(trusted-suppress-native-method, confirm, '"애드블록
 dogdrip.net,tvtv.us##+js(trusted-suppress-native-method, confirm, '"adblocker"', abort)
 dogdrip.net##+js(trusted-suppress-native-method, document.querySelectorAll, '"link"', abort)
 dogdrip.net##+js(trusted-suppress-native-method, document.querySelectorAll, '"style"', abort)
+! https://github.com/gorhill/uBlock/wiki/Resources-Library#trusted-suppress-native-methodjs-
+! https://github.com/gorhill/uBlock/blob/97d11c03c20bdc15877c342c404f179ca5c63ff6/assets/resources/scriptlets.js#L4872-L4875
+! Potential behavioral difference on scriptlet arguments: '/x$/' will escape $ but '"/x$/"' won't
 dogdrip.net##+js(trusted-suppress-native-method, String.prototype.concat, '"/^css-load.com$/"|"undefined"', abort)
 tvtv.us##+js(trusted-suppress-native-method, String.prototype.concat, '"/^html-load.com$/"|"undefined"', abort)

--- a/filters/fixes.txt
+++ b/filters/fixes.txt
@@ -1129,3 +1129,7 @@ dogdrip.net##+js(trusted-suppress-native-method, document.querySelectorAll, '"st
 dogdrip.net##+js(trusted-suppress-native-method, String.prototype.concat, '"/^css-load.com$/"|"undefined"', abort)
 tvtv.us##+js(trusted-suppress-native-method, String.prototype.concat, '"/^html-load.com$/"|"undefined"', abort)
 !#endif
+
+! https://github.com/ghostery/broken-page-reports/issues/1069
+utwente.nl#@#+js(trusted-set-cookie, utwente__avgconsent, {"a":false,"c":true,"v":"1","lc":"$currentDate$","isset":true}, , , domain, utwente.nl)
+utwente.nl##+js(set, utwenteCookies._consent, true)


### PR DESCRIPTION
fixes #877 *experimental, not recommended on Safari
fixes #1061 *experimental, not recommended on Safari

```
dogdrip.net,tvtv.us##+js(trusted-suppress-native-method, confirm, '"애드블록"', abort)
dogdrip.net,tvtv.us##+js(trusted-suppress-native-method, confirm, '"adblocker"', abort)
dogdrip.net##+js(trusted-suppress-native-method, document.querySelectorAll, '"link"', abort)
dogdrip.net##+js(trusted-suppress-native-method, document.querySelectorAll, '"style"', abort)
! https://github.com/gorhill/uBlock/wiki/Resources-Library#trusted-suppress-native-methodjs-
! https://github.com/gorhill/uBlock/blob/97d11c03c20bdc15877c342c404f179ca5c63ff6/assets/resources/scriptlets.js#L4872-L4875
! Potential behavioral difference on scriptlet arguments: '/x$/' will escape $ but '"/x$/"' won't
dogdrip.net##+js(trusted-suppress-native-method, String.prototype.concat, '"/^css-load.com$/"|"undefined"', abort)
tvtv.us##+js(trusted-suppress-native-method, String.prototype.concat, '"/^html-load.com$/"|"undefined"', abort)
```

fixes #1069

```
! https://github.com/ghostery/broken-page-reports/issues/1069
utwente.nl#@#+js(trusted-set-cookie, utwente__avgconsent, {"a":false,"c":true,"v":"1","lc":"$currentDate$","isset":true}, , , domain, utwente.nl)
utwente.nl##+js(set, utwenteCookies._consent, true)
```