### PR TITLE
fix(ci): typo in env key

### DIFF
--- a/.github/workflows/validate-issue-title.yaml
+++ b/.github/workflows/validate-issue-title.yaml
@@ -21,7 +21,7 @@ jobs:
           deno install
           {
             echo 'VALERR<<EOF'
-            echo "$(deno run './src/validate-issue-title.ts' "${name}" 2>&1 >/dev/null)"
+            echo "$(deno run './src/validate-issue-title.ts' "${NAME}" 2>&1 >/dev/null)"
             echo EOF
           } >> "$GITHUB_ENV"
       - name: In case of an invalid issue title, comment about the error and label the issue


### PR DESCRIPTION
Fixes typo of env key. See https://github.com/seia-soto/broken-page-reports-issue-title-validation-test/actions/runs/12705057388/job/35415437348 for the real world log.

refs https://github.com/ghostery/broken-page-reports/issues/1074#issuecomment-2581941811