### PR TITLE
chore(clean): Jan 27

### DIFF
--- a/filters/cookies.txt
+++ b/filters/cookies.txt
@@ -241,10 +241,6 @@ new.nortic.se##+js(set-cookie, nortic-cookies-consent, true)
 ! https://github.com/ghostery/broken-page-reports/issues/265
 ! https://github.com/ghostery/broken-page-reports/issues/761
 ! https://github.com/ghostery/broken-page-reports/issues/956
-! >>> url=https://regexmail.com/a
-! ... source=https://cbsnews.com/
-! ... type=xhr
-||regexmail.com^
 ! >>> url=https://marrowleaves.com/a
 ! ... source=https://usatoday.com/
 ! ... type=xhr

--- a/filters/cookies.txt
+++ b/filters/cookies.txt
@@ -241,10 +241,6 @@ new.nortic.se##+js(set-cookie, nortic-cookies-consent, true)
 ! https://github.com/ghostery/broken-page-reports/issues/265
 ! https://github.com/ghostery/broken-page-reports/issues/761
 ! https://github.com/ghostery/broken-page-reports/issues/956
-! >>> url=https://rehabilitatereason.com/a
-! ... source=https://15min.lt/
-! ... type=xhr
-||rehabilitatereason.com^
 ! >>> url=https://gigkarma.com/a
 ! ... source=https://usatoday.com/
 ! ... type=xhr

--- a/filters/cookies.txt
+++ b/filters/cookies.txt
@@ -241,10 +241,6 @@ new.nortic.se##+js(set-cookie, nortic-cookies-consent, true)
 ! https://github.com/ghostery/broken-page-reports/issues/265
 ! https://github.com/ghostery/broken-page-reports/issues/761
 ! https://github.com/ghostery/broken-page-reports/issues/956
-! >>> url=https://phonicsblitz.com/a
-! ... source=https://usatoday.com/
-! ... type=xhr
-||phonicsblitz.com^
 ! >>> url=https://rehabilitatereason.com/a
 ! ... source=https://15min.lt/
 ! ... type=xhr

--- a/filters/cookies.txt
+++ b/filters/cookies.txt
@@ -241,10 +241,6 @@ new.nortic.se##+js(set-cookie, nortic-cookies-consent, true)
 ! https://github.com/ghostery/broken-page-reports/issues/265
 ! https://github.com/ghostery/broken-page-reports/issues/761
 ! https://github.com/ghostery/broken-page-reports/issues/956
-! >>> url=https://lonelybulb.com/a
-! ... source=https://usatoday.com/
-! ... type=xhr
-||lonelybulb.com^
 ! >>> url=https://regexmail.com/a
 ! ... source=https://cbsnews.com/
 ! ... type=xhr

--- a/filters/cookies.txt
+++ b/filters/cookies.txt
@@ -245,10 +245,6 @@ new.nortic.se##+js(set-cookie, nortic-cookies-consent, true)
 ! ... source=https://usatoday.com/
 ! ... type=xhr
 ||gigkarma.com^
-! >>> url=https://sayinnovation.com/a
-! ... source=https://usatoday.com/
-! ... type=xhr
-||sayinnovation.com^
 ! >>> url=https://feedten.com/a
 ! ... source=https://usatoday.com/
 ! ... type=xhr

--- a/filters/cookies.txt
+++ b/filters/cookies.txt
@@ -241,10 +241,6 @@ new.nortic.se##+js(set-cookie, nortic-cookies-consent, true)
 ! https://github.com/ghostery/broken-page-reports/issues/265
 ! https://github.com/ghostery/broken-page-reports/issues/761
 ! https://github.com/ghostery/broken-page-reports/issues/956
-! >>> url=https://marrowleaves.com/a
-! ... source=https://usatoday.com/
-! ... type=xhr
-||marrowleaves.com^
 ! >>> url=https://rarestcandy.com/a
 ! ... source=https://usatoday.com/
 ! ... type=xhr

--- a/filters/cookies.txt
+++ b/filters/cookies.txt
@@ -241,10 +241,6 @@ new.nortic.se##+js(set-cookie, nortic-cookies-consent, true)
 ! https://github.com/ghostery/broken-page-reports/issues/265
 ! https://github.com/ghostery/broken-page-reports/issues/761
 ! https://github.com/ghostery/broken-page-reports/issues/956
-! >>> url=https://nevitable.com/a
-! ... source=https://usatoday.com/
-! ... type=xhr
-||nevitable.com^
 ! >>> url=https://lonelybulb.com/a
 ! ... source=https://usatoday.com/
 ! ... type=xhr

--- a/filters/cookies.txt
+++ b/filters/cookies.txt
@@ -241,10 +241,6 @@ new.nortic.se##+js(set-cookie, nortic-cookies-consent, true)
 ! https://github.com/ghostery/broken-page-reports/issues/265
 ! https://github.com/ghostery/broken-page-reports/issues/761
 ! https://github.com/ghostery/broken-page-reports/issues/956
-! >>> url=https://rarestcandy.com/a
-! ... source=https://usatoday.com/
-! ... type=xhr
-||rarestcandy.com^
 ! >>> url=https://phonicsblitz.com/a
 ! ... source=https://usatoday.com/
 ! ... type=xhr

--- a/filters/fixes.txt
+++ b/filters/fixes.txt
@@ -80,10 +80,6 @@ spiegel.de#@#+js(aopr, _sp_.mms.startMsg)
 ! ... match=true
 /reklama1.$3p
 
-! https://cliqztix.atlassian.net/browse/GH-1888
-! Ads are shown on the right: https://www.limetorrents.info/home/
-limetorrents.info##[href^="https://track.ultravpn.com/"]
-
 ! https://github.com/ghostery/browser-ios/pull/477
 ! Domain `simply.com` used to belong to an advertising company which was then
 ! bought recently by https://www.unoeuro.com/dk/ It is blocked by this filter

--- a/filters/privacy.txt
+++ b/filters/privacy.txt
@@ -22,12 +22,6 @@
 ! ... type=xhr
 ||api.bilibili.com/x/vip/ads/materials^$domain=bilibili.com
 
-! https://github.com/ghostery/broken-page-reports/issues/910
-! >>> url=https://yk.nobledtenuous.com/rxnIbsRJdiE8/wQLrB
-! ... source=https://www.braflix.is/
-! ... type=script
-||nobledtenuous.com^
-
 ! https://github.com/ghostery/broken-page-reports/issues/918
 ! >>> url=https://srbtztegq.today/245d0b678298d
 ! ... source=https://1337x.to/torrent/6244307/Twisters-2024-2160p-BluRay-x265-10bit-DV-HDR-TrueHD-Atmos-7-1-English-German-Spanish-Chinese-Czech-Polish-r00t-QxR/

--- a/filters/privacy.txt
+++ b/filters/privacy.txt
@@ -44,13 +44,6 @@
 ! ... type=xhr
 ||vauloops.net^
 
-! https://github.com/ghostery/broken-page-reports/issues/949
-! This is a duplicate entry from EasyList but shipping manually as it was not included in the final DNR sets
-! >>> url=https://phidaukrauvo.net/a
-! ... source=https://www.sflix.to/home
-! ... type=xhr
-||phidaukrauvo.net^
-
 ! https://github.com/ghostery/broken-page-reports/issues/1019
 ! >>> url=https://tracker.remp-beam.golem.de/track/event
 ! ... source=https://golem.de/

--- a/filters/privacy.txt
+++ b/filters/privacy.txt
@@ -16,12 +16,6 @@
 ! ... type=xhr
 @@||transcend.io^$third-party
 
-! https://github.com/ghostery/broken-page-reports/issues/630
-! >>> url=https://mm.osmatecosh.com/rcCQ8T6hfr9/QlXMq
-! ... source=https://1tamilblasters.pm/index.php?/forums/topic
-! ... type=script
-||mm.osmatecosh.com^
-
 ! https://github.com/ghostery/broken-page-reports/issues/688
 ! >>> url=api.bilibili.com/x/vip/ads/materials?position=52&position=53&platform=pc&buvid=infoc&code=pc-coupon&mid=
 ! ... source=https://www.bilibili.com/


### PR DESCRIPTION
This cleans up unused or duplicate filters with quickly scanned result.

- deprecate: unused, dead domain (double checked with shodan)
- duplicate: found on EL (quickly queried with ubo)

Most of admiral domains in use are now registered to EasyPrivacy.