### PR TITLE
Allow CMP: cookieinformation

### DIFF
--- a/filters/autoconsent-compatibility.txt
+++ b/filters/autoconsent-compatibility.txt
@@ -578,6 +578,11 @@ corona-in-zahlen.de#@#.cookiealert
 ! ... type=xhr
 @@||cookieinformation.com/*/*.js
 
+! >>> url=https://policy.app.cookieinformation.com/uc.js
+! ... source=https://www.dm-jobs.com/Germany/content/klingt-nach-dir/?locale=de_DE
+! ... type=script
+@@||cookieinformation.com^$3p
+
 ! https://github.com/ghostery/broken-page-reports/issues/71
 kerastase.fr#@#.cookie-label
 


### PR DESCRIPTION
Partially fixes https://github.com/ghostery/broken-page-reports/issues/1518

This stops CMP from being blocked. 