### PR TITLE
fix(flags): set FLAG_PAUSE_ASSISTANT percentage to 0

### DIFF
--- a/src/config/flags.ts
+++ b/src/config/flags.ts
@@ -38,7 +38,7 @@ const flags: Config["flags"] = {
   ],
   [FLAG_PAUSE_ASSISTANT]: [
     {
-      percentage: 10,
+      percentage: 0,
     },
   ],
 };


### PR DESCRIPTION
Due to current bugs in the production code, we must disable the feature until a new version with fixes is released.