### PR TITLE
fix(flags): turn down the `FLAG_CHROMIUM_INJECT_COSMETICS_ON_RESPONSE_STARTED` flag

### DIFF
--- a/src/config/flags.ts
+++ b/src/config/flags.ts
@@ -20,7 +20,7 @@ const flags: Config["flags"] = {
   ],
   [FLAG_CHROMIUM_INJECT_COSMETICS_ON_RESPONSE_STARTED]: [
     {
-      percentage: 50,
+      percentage: 0,
       filter: {
         platform: [PLATFORM_CHROMIUM],
       },


### PR DESCRIPTION
The recent version of Chrome fails to inject cosmetics in the `onResponseStarted` event. There is a possible solution to the issue, but it requires updating the source code. 

We have to temporarily turn down the flag.