### PR TITLE
flags: set FLAG_CHROMIUM_INJECT_COSMETICS_ON_RESPONSE_STARTED to 25%

### DIFF
--- a/src/config/flags.ts
+++ b/src/config/flags.ts
@@ -20,7 +20,7 @@ const flags: Config["flags"] = {
   ],
   [FLAG_CHROMIUM_INJECT_COSMETICS_ON_RESPONSE_STARTED]: [
     {
-      percentage: 0,
+      percentage: 25,
       filter: {
         platform: [PLATFORM_CHROMIUM],
       },


### PR DESCRIPTION
We can safely bring the flag back. Fixes have been released with v10.5.19. We currently have almost all active users on this version or newer v10.5.20.