### PR TITLE
chore: refresh adshield rules

### DIFF
--- a/filters/fixes.txt
+++ b/filters/fixes.txt
@@ -1444,56 +1444,6 @@ winfuture.de##body[style="overflow: hidden;"]:style(overflow: initial !important
 ! ... type=script
 ||loopmertb.com^
 
-! https://github.com/ghostery/broken-page-reports/issues/1047
-! https://github.com/ghostery/broken-page-reports/issues/1188
-! https://github.com/ghostery/broken-page-reports/issues/1919
-! https://github.com/ghostery/broken-page-reports/issues/1953
-! https://github.com/ghostery/broken-page-reports/issues/1949
-! https://github.com/ghostery/broken-page-reports/issues/1996
-! https://github.com/ghostery/broken-page-reports/issues/1406
-! https://github.com/ghostery/broken-page-reports/issues/942
-! https://github.com/ghostery/broken-page-reports/issues/1445
-! https://github.com/ghostery/broken-page-reports/issues/1605
-! https://github.com/ghostery/broken-page-reports/issues/1540
-! https://github.com/ghostery/broken-page-reports/issues/2016
-! >>> url=https://evenpatroller.com/loader.min.js
-! ... source=https://flagle.io
-! ... type=script
-||evenpatroller.com^$domain=flagle.io|newatlas.com|slashdot.org|picrew.me|weatherzone.com.au
-! >>> url=https://html-load.com/loader.min.js
-! ... source=https://flagle.io
-! ... type=script
-||html-load.com^$domain=flagle.io|newatlas.com|slashdot.org|picrew.me|weatherzone.com.au
-! >>> url=https://content-loader.com/loader.min.js
-! ... source=https://flagle.io
-! ... type=script
-||content-loader.com^$domain=flagle.io|newatlas.com|slashdot.org|picrew.me|weatherzone.com.au
-! >>> url=https://error-report.com/loader.min.js
-! ... source=https://flagle.io
-! ... type=script
-||error-report.com^$domain=flagle.io|newatlas.com|slashdot.org|picrew.me|sourceforge.net|weatherzone.com.au
-! >>> url=https://0.as.slashdot.org/
-! ... source=https://slashdot.org/
-! ... type=script
-||as.slashdot.org^
-! >>> url=https://0.as.sourceforge.net/
-! ... source=https://sourceforge.net/projects/analyseplugin/
-! ... type=script
-||as.sourceforge.net^
-! https://github.com/gorhill/uBlock/wiki/Resources-Library#trusted-suppress-native-methodjs-
-! https://github.com/gorhill/uBlock/blob/97d11c03c20bdc15877c342c404f179ca5c63ff6/assets/resources/scriptlets.js#L4872-L4875
-! Potential behavioral difference on scriptlet arguments: '/x$/' will escape $ but '"/x$/"' won't
-motscroises.fr##+js(trusted-suppress-native-method, String.prototype.concat, '"/^css-load.com$/"|"undefined"', abort)
-motscroises.fr,onlinegdb.com,newsinlevels.com,wetter.com,flagle.io##+js(trusted-suppress-native-method, String.prototype.concat, '"/^html-load.com$/"|"undefined"', abort)
-flagle.io,newatlas.com##+js(aopr, HTMLStyleElement.prototype.remove)
-flagle.io,newatlas.com##+js(aopr, HTMLLinkElement.prototype.remove)
-flagle.io,newatlas.com##+js(aopr, confirm)
-newatlas.com##+js(aopr, atob)
-weatherzone.com.au,slashdot.org,picrew.me,tvtv.us,sourceforge.net##+js(trusted-suppress-native-method, atob, '"VGhpcyBwYWdlIGNvdWxkIG5vdCBiZSBsb2Fk"', abort)
-weatherzone.com.au,slashdot.org,picrew.me,tvtv.us,sourceforge.net##+js(trusted-suppress-native-method, atob, '"YWRibG9ja2"', abort)
-weatherzone.com.au,slashdot.org,picrew.me,tvtv.us,sourceforge.net##+js(trusted-suppress-native-method, URL.prototype.constructor, '"error-report.com"', abort)
-weatherzone.com.au,slashdot.org,picrew.me,tvtv.us,sourceforge.net##+js(trusted-suppress-native-method, console.error, '"html-load.com"', abort)
-
 ! https://github.com/ghostery/broken-page-reports/issues/1570
 nytimes.com##div[class^="Ad-module_adContainer"]
 


### PR DESCRIPTION
This refreshing the adshield rules. It helps adoptation of community rules. Ghostery specific rules are meant to be used on unstable scripting environments along with the community rules.