### PR TITLE
flags: bump `INJECTION_TARGET_DOCUMENT_ID` flag to 100%

### DIFF
--- a/src/config/flags.ts
+++ b/src/config/flags.ts
@@ -43,7 +43,7 @@ const flags: Config["flags"] = {
   ],
   [FLAG_INJECTION_TARGET_DOCUMENT_ID]: [
     {
-      percentage: 25,
+      percentage: 100,
     },
   ],
   [FLAG_MODES]: [


### PR DESCRIPTION
The flag has been proved with 25% coverage. As the flag is required on Safari to block properly on subframes, I recommend bumping the flag to 100%.