### PR TITLE
fix(flags): remove `platform` check from `FIREFOX_CONTENT_SCRIPT_SCRIPTLETS` flag

### DIFF
--- a/src/config/flags.ts
+++ b/src/config/flags.ts
@@ -17,9 +17,6 @@ const flags: Config["flags"] = {
   [FLAG_FIREFOX_CONTENT_SCRIPT_SCRIPTLETS]: [
     {
       percentage: 100,
-      filter: {
-        platform: [PLATFORM_FIREFOX],
-      },
     },
   ],
   [FLAG_CHROMIUM_INJECT_COSMETICS_ON_RESPONSE_STARTED]: [


### PR DESCRIPTION
The `FIREFOX_CONTENT_SCRIPT_SCRIPTLETS` is used in the code only on Firefox, so the `platform` check is not required. 

We are going to change `platform` check with `browser`, so we need to clean up `platform`, to avoid disabling the feature (the `platform` won't be recognized in newer versions of the extension).