### PR TITLE
flags: bump `SUBFRAME_SCRIPTING` to 15%

### DIFF
--- a/src/config/flags.ts
+++ b/src/config/flags.ts
@@ -70,7 +70,7 @@ const flags: Config["flags"] = {
   ],
   [FLAG_SUBFRAME_SCRIPTING]: [
     {
-      percentage: 0,
+      percentage: 15,
     },
   ],
 };


### PR DESCRIPTION
We are now shipping the feature with the extension version 10.5.29. We now want to try actually deploying it in low percentage and see how it will go.