### PR TITLE
flags: bump `REVIEW_NOTIFICATION` and `MODES`

### DIFF
--- a/packages/config/src/browsers.ts
+++ b/packages/config/src/browsers.ts
@@ -1,0 +1,31 @@
+// Copyright 2025-2026 Ghostery GmbH
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+export const BROWSER_CHROME = "chrome";
+export const BROWSER_EDGE = "edge";
+export const BROWSER_OPERA = "opera";
+export const BROWSER_BRAVE = "brave";
+export const BROWSER_OCULUS = "oculus";
+export const BROWSER_YANDEX = "yandex";
+export const BROWSER_SAFARI = "safari";
+export const BROWSER_FIREFOX = "firefox";
+
+export const BROWSERS = [
+  BROWSER_CHROME,
+  BROWSER_EDGE,
+  BROWSER_OPERA,
+  BROWSER_BRAVE,
+  BROWSER_OCULUS,
+  BROWSER_YANDEX,
+  BROWSER_SAFARI,
+  BROWSER_FIREFOX,
+] as const;
+
+export type Browser = typeof BROWSERS[number];
+
+export function isBrowser(browser: string): browser is Browser {
+  return (BROWSERS as readonly string[]).includes(browser);
+}

--- a/packages/config/src/flags.ts
+++ b/packages/config/src/flags.ts
@@ -4,7 +4,6 @@
 // license that can be found in the LICENSE file or at
 // https://opensource.org/licenses/MIT.
 
-
 // ---- Active flags ----
 
 export const FLAG_CHROMIUM_INJECT_COSMETICS_ON_RESPONSE_STARTED = "chromium-inject-cosmetics-on-response-started";

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -4,16 +4,23 @@
 // license that can be found in the LICENSE file or at
 // https://opensource.org/licenses/MIT.
 
+export * from "./browsers.js";
 export * from "./platforms.js";
 export * from "./actions.js";
 export * from "./flags.js";
 
+import type { Browser } from "./browsers.js";
 import type { Platform } from "./platforms.js";
 import type { Action } from "./actions.js";
 import type { Flag } from "./flags.js";
 
+// type like "1.0.0", "2.3.4"
+export type Version = `${number}.${number}.${number}`;
+
 interface Filter {
   platform?: Platform[];
+  browser?: Browser;
+  version?: Version;
 }
 
 export interface Config {

--- a/src/config/flags.ts
+++ b/src/config/flags.ts
@@ -1,4 +1,5 @@
 import {
+  BROWSER_CHROME,
   Config,
   FLAG_CHROMIUM_INJECT_COSMETICS_ON_RESPONSE_STARTED,
   FLAG_DYNAMIC_DNR_FIXES,
@@ -24,7 +25,7 @@ const flags: Config["flags"] = {
     { percentage: 100 },
   ],
   [FLAG_MODES]: [
-    { percentage: 0 },
+    { percentage: 10, filter: { browser: BROWSER_CHROME, version: "10.5.30" } },
   ],
   [FLAG_PAUSE_ASSISTANT]: [
     { percentage: 100 },


### PR DESCRIPTION
* Bump `REVIEW_NOTIFICATION` to 60%
* Bump `MODES` to 10% - includes config types update for `browser` and `version` filters. The `version` filter check was introduced in `10.5.26`, so adoption should be almost 100% active users.

REBASE when merging.