### PR TITLE
fix(remote-config): move completed flags to completed section

### DIFF
--- a/packages/config/src/flags.ts
+++ b/packages/config/src/flags.ts
@@ -6,21 +6,15 @@
 
 // ---- Active flags ----
 
-export const FLAG_CHROMIUM_INJECT_COSMETICS_ON_RESPONSE_STARTED = "chromium-inject-cosmetics-on-response-started";
-export const FLAG_INJECTION_TARGET_DOCUMENT_ID = "injection-target-document-id";
 export const FLAG_MODES = "modes";
 export const FLAG_PAUSE_ASSISTANT = "pause-assistant";
-export const FLAG_REDIRECT_PROTECTION = "redirect-protection";
 export const FLAG_ONBOARDING_SURVEY = "onboarding-survey";
 export const FLAG_NOTIFICATION_REVIEW = "notification-review";
 export const FLAG_SUBFRAME_SCRIPTING = "subframe-scripting";
 
 export const FLAGS = [
-  FLAG_CHROMIUM_INJECT_COSMETICS_ON_RESPONSE_STARTED,
-  FLAG_INJECTION_TARGET_DOCUMENT_ID,
   FLAG_MODES,
   FLAG_PAUSE_ASSISTANT,
-  FLAG_REDIRECT_PROTECTION,
   FLAG_ONBOARDING_SURVEY,
   FLAG_NOTIFICATION_REVIEW,
   FLAG_SUBFRAME_SCRIPTING,
@@ -28,14 +22,20 @@ export const FLAGS = [
 
 // ---- Completed flags ----
 
+export const FLAG_CHROMIUM_INJECT_COSMETICS_ON_RESPONSE_STARTED = "chromium-inject-cosmetics-on-response-started";
 export const FLAG_DYNAMIC_DNR_FIXES = "dynamic-dnr-fixes";
 export const FLAG_EXTENDED_SELECTORS = "extended-selectors";
 export const FLAG_FIREFOX_CONTENT_SCRIPT_SCRIPTLETS = "firefox-content-script-scriptlets";
+export const FLAG_INJECTION_TARGET_DOCUMENT_ID = "injection-target-document-id";
+export const FLAG_REDIRECT_PROTECTION = "redirect-protection";
 
 const COMPLETED_FLAGS = [
+  FLAG_CHROMIUM_INJECT_COSMETICS_ON_RESPONSE_STARTED,
   FLAG_DYNAMIC_DNR_FIXES,
   FLAG_EXTENDED_SELECTORS,
   FLAG_FIREFOX_CONTENT_SCRIPT_SCRIPTLETS,
+  FLAG_INJECTION_TARGET_DOCUMENT_ID,
+  FLAG_REDIRECT_PROTECTION,
 ] as const;
 
 // ---- Types and utility functions ----

--- a/src/config/flags.ts
+++ b/src/config/flags.ts
@@ -19,20 +19,11 @@ import {
 // ---- Active flags ----
 
 const flags: Config["flags"] = {
-  [FLAG_CHROMIUM_INJECT_COSMETICS_ON_RESPONSE_STARTED]: [
-    { percentage: 100 },
-  ],
-  [FLAG_INJECTION_TARGET_DOCUMENT_ID]: [
-    { percentage: 100 },
-  ],
   [FLAG_MODES]: [
     { percentage: 100, filter: { browser: BROWSER_BRAVE, version: "10.5.30" } },
     { percentage: 25, filter: { version: "10.5.30" } },
   ],
   [FLAG_PAUSE_ASSISTANT]: [
-    { percentage: 100 },
-  ],
-  [FLAG_REDIRECT_PROTECTION]: [
     { percentage: 100 },
   ],
   [FLAG_ONBOARDING_SURVEY]: [
@@ -60,6 +51,18 @@ const completedFlags: Config["flags"] = {
   // https://github.com/ghostery/ghostery-extension/pull/3051
   [FLAG_FIREFOX_CONTENT_SCRIPT_SCRIPTLETS]: [
     { percentage: 100, filter: { platform: [PLATFORM_FIREFOX] } },
+  ],
+  // https://github.com/ghostery/ghostery-extension/pull/3263
+  [FLAG_REDIRECT_PROTECTION]: [
+    { percentage: 100 },
+  ],
+  // https://github.com/ghostery/ghostery-extension/pull/3270
+  [FLAG_CHROMIUM_INJECT_COSMETICS_ON_RESPONSE_STARTED]: [
+    { percentage: 100 },
+  ],
+  // https://github.com/ghostery/ghostery-extension/pull/3270
+  [FLAG_INJECTION_TARGET_DOCUMENT_ID]: [
+    { percentage: 100 },
   ],
 };
 


### PR DESCRIPTION
Moves three flags that have been fully rolled out and removed from the extension codebase into the completed flags section.

- `FLAG_INJECTION_TARGET_DOCUMENT_ID` and `FLAG_CHROMIUM_INJECT_COSMETICS_ON_RESPONSE_STARTED` — cleaned up in https://github.com/ghostery/ghostery-extension/pull/3270
- `FLAG_REDIRECT_PROTECTION` — cleaned up in https://github.com/ghostery/ghostery-extension/pull/3263