### PR TITLE
fix: allow sendibm1.com email tracking links

### DIFF
--- a/filters/fixes.txt
+++ b/filters/fixes.txt
@@ -2424,3 +2424,9 @@ cybermania.ws##body:style(overflow: initial !important)
 blick.ch##.tp-modal:has([allow="payment"])
 blick.ch##body.tp-modal-open:has(.tp-modal [allow="payment"]) > .tp-backdrop
 blick.ch##body.tp-modal-open:has(.tp-modal [allow="payment"]):style(overflow: initial !important)
+
+! Allow Brevo/Sendinblue email tracking links to resolve so newsletter redirects work
+! >>> url=https://r.sendibm1.com/mk/cl/f/sh/abc123/xyz
+! ... source=https://example.com/
+! ... type=document
+@@||sendibm1.com/mk/$document


### PR DESCRIPTION
## Summary
- Whitelists top-level navigation to `sendibm1.com/mk/` so Brevo/Sendinblue newsletter redirect links resolve to their destinations instead of being blocked.

## Test plan
- [ ] Click a Brevo/Sendinblue newsletter link (e.g. `https://r.sendibm1.com/mk/cl/f/sh/...`) and confirm the browser follows the redirect to the intended page.