### PR TITLE
chore: bump modes flag to 50%

### DIFF
--- a/src/config/flags.ts
+++ b/src/config/flags.ts
@@ -21,7 +21,7 @@ import {
 const flags: Config["flags"] = {
   [FLAG_MODES]: [
     { percentage: 100, filter: { browser: BROWSER_BRAVE, version: "10.5.30" } },
-    { percentage: 25, filter: { version: "10.5.30" } },
+    { percentage: 50, filter: { version: "10.5.30" } },
   ],
   [FLAG_PAUSE_ASSISTANT]: [
     { percentage: 100 },


### PR DESCRIPTION
Bumps the `modes` flag rollout percentage from 25% to 50%.