### PR TITLE
flags: bump MODES flag to 100%

### DIFF
--- a/src/config/flags.ts
+++ b/src/config/flags.ts
@@ -1,6 +1,4 @@
 import {
-  BROWSER_BRAVE,
-  BROWSER_CHROME,
   Config,
   FLAG_CHROMIUM_INJECT_COSMETICS_ON_RESPONSE_STARTED,
   FLAG_DYNAMIC_DNR_FIXES,
@@ -20,8 +18,7 @@ import {
 
 const flags: Config["flags"] = {
   [FLAG_MODES]: [
-    { percentage: 100, filter: { browser: BROWSER_BRAVE, version: "10.5.30" } },
-    { percentage: 50, filter: { version: "10.5.30" } },
+    { percentage: 100, filter: { version: "10.5.30" } },
   ],
   [FLAG_PAUSE_ASSISTANT]: [
     { percentage: 100 },


### PR DESCRIPTION
Bumps the `modes` flag from 50% to 100% for all users on version `10.5.30`.

The previous config had two entries — one at 100% for Brave and one at 50% for everyone else. This consolidates them into a single 100% entry for all browsers.