### PR TITLE
chore(config): update filter.browser from string to array

### DIFF
--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -19,7 +19,7 @@ export type Version = `${number}.${number}.${number}`;
 
 interface Filter {
   platform?: Platform[];
-  browser?: Browser;
+  browser?: Browser[];
   version?: Version;
 }
 


### PR DESCRIPTION
The `filter.browser` field in the shared `@ghostery/config` package was typed as a single `Browser` string, inconsistent with `filter.platform` which already accepts an array. This made it impossible to target multiple browsers with a single filter entry.

This changes `browser?: Browser` to `browser?: Browser[]` in the `Filter` interface, aligning it with the `platform` field pattern. This is the config-package counterpart to the same change made in the extension source code: ghostery/ghostery-extension#3379.