### PR TITLE
fix(remote-config): move pause-assistant flag to completed section

### DIFF
--- a/packages/config/src/flags.ts
+++ b/packages/config/src/flags.ts
@@ -7,14 +7,12 @@
 // ---- Active flags ----
 
 export const FLAG_MODES = "modes";
-export const FLAG_PAUSE_ASSISTANT = "pause-assistant";
 export const FLAG_ONBOARDING_SURVEY = "onboarding-survey";
 export const FLAG_NOTIFICATION_REVIEW = "notification-review";
 export const FLAG_SUBFRAME_SCRIPTING = "subframe-scripting";
 
 export const FLAGS = [
   FLAG_MODES,
-  FLAG_PAUSE_ASSISTANT,
   FLAG_ONBOARDING_SURVEY,
   FLAG_NOTIFICATION_REVIEW,
   FLAG_SUBFRAME_SCRIPTING,
@@ -27,6 +25,7 @@ export const FLAG_DYNAMIC_DNR_FIXES = "dynamic-dnr-fixes";
 export const FLAG_EXTENDED_SELECTORS = "extended-selectors";
 export const FLAG_FIREFOX_CONTENT_SCRIPT_SCRIPTLETS = "firefox-content-script-scriptlets";
 export const FLAG_INJECTION_TARGET_DOCUMENT_ID = "injection-target-document-id";
+export const FLAG_PAUSE_ASSISTANT = "pause-assistant";
 export const FLAG_REDIRECT_PROTECTION = "redirect-protection";
 
 const COMPLETED_FLAGS = [
@@ -35,6 +34,7 @@ const COMPLETED_FLAGS = [
   FLAG_EXTENDED_SELECTORS,
   FLAG_FIREFOX_CONTENT_SCRIPT_SCRIPTLETS,
   FLAG_INJECTION_TARGET_DOCUMENT_ID,
+  FLAG_PAUSE_ASSISTANT,
   FLAG_REDIRECT_PROTECTION,
 ] as const;
 

--- a/src/config/flags.ts
+++ b/src/config/flags.ts
@@ -20,9 +20,6 @@ const flags: Config["flags"] = {
   [FLAG_MODES]: [
     { percentage: 100, filter: { version: "10.5.30" } },
   ],
-  [FLAG_PAUSE_ASSISTANT]: [
-    { percentage: 100 },
-  ],
   [FLAG_ONBOARDING_SURVEY]: [
     { percentage: 20 },
   ],
@@ -59,6 +56,10 @@ const completedFlags: Config["flags"] = {
   ],
   // https://github.com/ghostery/ghostery-extension/pull/3270
   [FLAG_INJECTION_TARGET_DOCUMENT_ID]: [
+    { percentage: 100 },
+  ],
+  // https://github.com/ghostery/ghostery-extension/pull/3380
+  [FLAG_PAUSE_ASSISTANT]: [
     { percentage: 100 },
   ],
 };


### PR DESCRIPTION
Moves the `pause-assistant` flag that has been fully rolled out and removed from the extension codebase into the completed flags section.

- `FLAG_PAUSE_ASSISTANT` — cleaned up in https://github.com/ghostery/ghostery-extension/pull/3380