### PR TITLE
fix(config): tolerate transient GitHub API failures during generation

### DIFF
--- a/src/config/generate.ts
+++ b/src/config/generate.ts
@@ -16,7 +16,9 @@ const config: Config = {
   flags,
 };
 
-const octokit = new Octokit();
+const octokit = new Octokit({
+  retry: { retries: 6 },
+});
 
 const iterator = octokit.paginate.iterator(octokit.rest.issues.listForRepo, {
   owner: "ghostery",


### PR DESCRIPTION
## Problem

The timer-triggered `config:generate` Jenkins job intermittently fails when GitHub returns a transient gateway error (e.g. a `504 Gateway Time-out`) while paginating over issues. Octokit's default retry budget (3 attempts) gets exhausted during the outage window, the unhandled rejection exits the process with code 1, and the whole pipeline is marked failed (and Slack-pinged).

This isn't triggered by any code change — `generate.ts` hasn't been touched in a long time. It's purely GitHub-side flakiness that the script doesn't currently ride out.

## Change

Widen the Octokit retry budget so a brief GitHub outage is absorbed instead of breaking a job that only runs on a timer.

## Test plan

- Re-run the config generation job; it should produce `config/v1.json` as before.