### PR TITLE
fix(ceneo.pl): unhide top billboard to stop page freeze

### DIFF
--- a/filters/fixes.txt
+++ b/filters/fixes.txt
@@ -2468,3 +2468,6 @@ bondagevalley.cc##.pleasedoit
 
 ! https://github.com/ghostery/broken-page-reports/issues/2268
 go.globo.com##.desktop-ad-on-resize
+
+! https://github.com/ghostery/broken-page-reports/issues/2322
+ceneo.pl#@#.ado-top-billboard


### PR DESCRIPTION
## Summary

Fixes ceneo.pl freezing by adding an unhide rule for `.ado-top-billboard`. A cosmetic filter hiding this billboard slot was triggering the page freeze, so we allowlist the element on ceneo.pl.

Closes #2322

## Test plan

- Open ceneo.pl with Ghostery enabled
- Page should load and stay responsive (no freeze)