### PR TITLE
fix(onet.pl): remove cmp class to restore scrolling

### DIFF
--- a/filters/cookies.txt
+++ b/filters/cookies.txt
@@ -707,8 +707,10 @@ standaardboekhandel.be#@#.modal-backdrop
 standaardboekhandel.be#@#.modal
 
 ! https://github.com/ghostery/broken-page-reports/issues/2100
+! https://github.com/ghostery/broken-page-reports/issues/2294
 onet.pl##div.cmp-app_gdpr
 onet.pl##body.cmp:style(overflow: initial !important)
+onet.pl##body:remove-class(cmp)
 
 ! https://github.com/ghostery/broken-page-reports/issues/2104
 consumentenbond.nl##div[data-test-consent-banner]

--- a/filters/cookies.txt
+++ b/filters/cookies.txt
@@ -710,7 +710,7 @@ standaardboekhandel.be#@#.modal
 ! https://github.com/ghostery/broken-page-reports/issues/2294
 onet.pl##div.cmp-app_gdpr
 onet.pl##body.cmp:style(overflow: initial !important)
-onet.pl##body:remove-class(cmp)
+onet.pl##+js(remove-class, cmp, body)
 
 ! https://github.com/ghostery/broken-page-reports/issues/2104
 consumentenbond.nl##div[data-test-consent-banner]


### PR DESCRIPTION
Adds a fix for onet.pl where the consent management (`cmp`) class on `<body>` leaves the page unscrollable.

The site already had two consent-related filters grouped under #2100; this adds `onet.pl##body:remove-class(cmp)` alongside them to strip the offending class outright and restore normal page interaction.

Closes #2294

## Test plan
- Visit https://onet.pl with Ghostery enabled.
- Confirm the page can be scrolled normally and is not frozen/locked.
- Confirm no consent overlay remains blocking the content.