### PR TITLE
feat(flags): add panel-notification-survey flag

### DIFF
--- a/packages/config/src/flags.ts
+++ b/packages/config/src/flags.ts
@@ -10,12 +10,14 @@ export const FLAG_MODES = "modes";
 export const FLAG_ONBOARDING_SURVEY = "onboarding-survey";
 export const FLAG_NOTIFICATION_REVIEW = "notification-review";
 export const FLAG_SUBFRAME_SCRIPTING = "subframe-scripting";
+export const FLAG_PANEL_NOTIFICATION_SURVEY = "panel-notification-survey";
 
 export const FLAGS = [
   FLAG_MODES,
   FLAG_ONBOARDING_SURVEY,
   FLAG_NOTIFICATION_REVIEW,
   FLAG_SUBFRAME_SCRIPTING,
+  FLAG_PANEL_NOTIFICATION_SURVEY,
 ] as const;
 
 // ---- Completed flags ----

--- a/src/config/flags.ts
+++ b/src/config/flags.ts
@@ -8,6 +8,7 @@ import {
   FLAG_MODES,
   FLAG_NOTIFICATION_REVIEW,
   FLAG_ONBOARDING_SURVEY,
+  FLAG_PANEL_NOTIFICATION_SURVEY,
   FLAG_PAUSE_ASSISTANT,
   FLAG_REDIRECT_PROTECTION,
   FLAG_SUBFRAME_SCRIPTING,
@@ -27,6 +28,9 @@ const flags: Config["flags"] = {
     { percentage: 90 },
   ],
   [FLAG_SUBFRAME_SCRIPTING]: [
+    { percentage: 100 },
+  ],
+  [FLAG_PANEL_NOTIFICATION_SURVEY]: [
     { percentage: 100 },
   ],
 };


### PR DESCRIPTION
Adds a new `panel-notification-survey` feature flag to support a panel-based notification survey flow. The flag is registered in the `@ghostery/config` package alongside existing active flags and enabled at 100% rollout in the configuration.