### PR TITLE
chore(flags): disable panel notification survey flag

### DIFF
--- a/src/config/flags.ts
+++ b/src/config/flags.ts
@@ -31,7 +31,7 @@ const flags: Config["flags"] = {
     { percentage: 100 },
   ],
   [FLAG_PANEL_NOTIFICATION_SURVEY]: [
-    { percentage: 100 },
+    { percentage: 0 },
   ],
 };
 


### PR DESCRIPTION
The panel notification survey flag (`FLAG_PANEL_NOTIFICATION_SURVEY`) was previously rolled out to 100% of users. This PR disables it by setting the rollout percentage to 0%.