### PR TITLE
Add FLAG_DNR_SERP feature flag

### DIFF
--- a/packages/config/src/flags.ts
+++ b/packages/config/src/flags.ts
@@ -11,6 +11,7 @@ export const FLAG_ONBOARDING_SURVEY = "onboarding-survey";
 export const FLAG_NOTIFICATION_REVIEW = "notification-review";
 export const FLAG_SUBFRAME_SCRIPTING = "subframe-scripting";
 export const FLAG_PANEL_NOTIFICATION_SURVEY = "panel-notification-survey";
+export const FLAG_DNR_SERP = "dnr-serp";
 
 export const FLAGS = [
   FLAG_MODES,
@@ -18,6 +19,7 @@ export const FLAGS = [
   FLAG_NOTIFICATION_REVIEW,
   FLAG_SUBFRAME_SCRIPTING,
   FLAG_PANEL_NOTIFICATION_SURVEY,
+  FLAG_DNR_SERP,
 ] as const;
 
 // ---- Completed flags ----

--- a/src/config/flags.ts
+++ b/src/config/flags.ts
@@ -11,6 +11,7 @@ import {
   FLAG_PANEL_NOTIFICATION_SURVEY,
   FLAG_PAUSE_ASSISTANT,
   FLAG_REDIRECT_PROTECTION,
+  FLAG_DNR_SERP,
   FLAG_SUBFRAME_SCRIPTING,
   PLATFORM_FIREFOX,
 } from "@ghostery/config";
@@ -32,6 +33,9 @@ const flags: Config["flags"] = {
   ],
   [FLAG_PANEL_NOTIFICATION_SURVEY]: [
     { percentage: 0 },
+  ],
+  [FLAG_DNR_SERP]: [
+    { percentage: 100 },
   ],
 };
 


### PR DESCRIPTION
The extension needs a new feature flag to control the DNR SERP functionality and allow gradual rollout. This adds `FLAG_DNR_SERP` as a new active flag with an initial rollout of 100%, defined in the config package and wired into the config generator.