### PR TITLE
fix(flags): disable FLAG_DNR_SERP

### DIFF
--- a/src/config/flags.ts
+++ b/src/config/flags.ts
@@ -35,7 +35,7 @@ const flags: Config["flags"] = {
     { percentage: 0 },
   ],
   [FLAG_DNR_SERP]: [
-    { percentage: 100 },
+    { percentage: 0 },
   ],
 };
 


### PR DESCRIPTION
This changes the FLAG_DNR_SERP percentage from 100 to 0, effectively disabling the DNR SERP feature.