### PR TITLE
fix(ci): move deno lint command to non-filter test workflow

### DIFF
--- a/.github/workflows/test-filters.yaml
+++ b/.github/workflows/test-filters.yaml
@@ -22,6 +22,5 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: jdx/mise-action@v2
-      - run: deno run lint
       - run: deno run tests
       - run: deno run build

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -24,6 +24,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: jdx/mise-action@v2
       - run: deno run lint
+        working-directory: ./
       - run: npm ci
       - run: npm run test
       - run: npm run build

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -23,6 +23,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: jdx/mise-action@v2
+      - run: deno run lint
       - run: npm ci
       - run: npm run test
       - run: npm run build


### PR DESCRIPTION
The ci was failing because of deno formatting error. However, it was not kept with CI because deno formatting check was only in filter related CI workflows. I'm moving this out of filter related test pipeline to source related test pipeline.