### PR TITLE
feat(config): add WHATS_NEW flag

### DIFF
--- a/packages/config/src/flags.ts
+++ b/packages/config/src/flags.ts
@@ -12,6 +12,7 @@ export const FLAG_NOTIFICATION_REVIEW = "notification-review";
 export const FLAG_SUBFRAME_SCRIPTING = "subframe-scripting";
 export const FLAG_PANEL_NOTIFICATION_SURVEY = "panel-notification-survey";
 export const FLAG_DNR_SERP = "dnr-serp";
+export const FLAG_WHATS_NEW = "whats-new";
 
 export const FLAGS = [
   FLAG_MODES,
@@ -20,6 +21,7 @@ export const FLAGS = [
   FLAG_SUBFRAME_SCRIPTING,
   FLAG_PANEL_NOTIFICATION_SURVEY,
   FLAG_DNR_SERP,
+  FLAG_WHATS_NEW,
 ] as const;
 
 // ---- Completed flags ----

--- a/src/config/flags.ts
+++ b/src/config/flags.ts
@@ -13,6 +13,7 @@ import {
   FLAG_PAUSE_ASSISTANT,
   FLAG_REDIRECT_PROTECTION,
   FLAG_SUBFRAME_SCRIPTING,
+  FLAG_WHATS_NEW,
   PLATFORM_FIREFOX,
 } from "@ghostery/config";
 
@@ -35,6 +36,9 @@ const flags: Config["flags"] = {
     { percentage: 0 },
   ],
   [FLAG_DNR_SERP]: [
+    { percentage: 0 },
+  ],
+  [FLAG_WHATS_NEW]: [
     { percentage: 0 },
   ],
 };


### PR DESCRIPTION
Adds a new feature flag to support an upcoming "what's new" panel notification, following the existing flag pattern used for other rollout flags.

Introduces `FLAG_WHATS_NEW` ("whats-new") in the shared config package and registers it in the active flags list, then wires it into the extension's runtime config with an initial rollout percentage of 0.