### PR TITLE
chore(flags): move FLAG_MODES to completed flags

### DIFF
--- a/packages/config/src/flags.ts
+++ b/packages/config/src/flags.ts
@@ -6,7 +6,6 @@
 
 // ---- Active flags ----
 
-export const FLAG_MODES = "modes";
 export const FLAG_ONBOARDING_SURVEY = "onboarding-survey";
 export const FLAG_NOTIFICATION_REVIEW = "notification-review";
 export const FLAG_SUBFRAME_SCRIPTING = "subframe-scripting";
@@ -15,7 +14,6 @@ export const FLAG_DNR_SERP = "dnr-serp";
 export const FLAG_WHATS_NEW = "whats-new";
 
 export const FLAGS = [
-  FLAG_MODES,
   FLAG_ONBOARDING_SURVEY,
   FLAG_NOTIFICATION_REVIEW,
   FLAG_SUBFRAME_SCRIPTING,
@@ -33,6 +31,7 @@ export const FLAG_FIREFOX_CONTENT_SCRIPT_SCRIPTLETS = "firefox-content-script-sc
 export const FLAG_INJECTION_TARGET_DOCUMENT_ID = "injection-target-document-id";
 export const FLAG_PAUSE_ASSISTANT = "pause-assistant";
 export const FLAG_REDIRECT_PROTECTION = "redirect-protection";
+export const FLAG_MODES = "modes";
 
 const COMPLETED_FLAGS = [
   FLAG_CHROMIUM_INJECT_COSMETICS_ON_RESPONSE_STARTED,
@@ -42,6 +41,7 @@ const COMPLETED_FLAGS = [
   FLAG_INJECTION_TARGET_DOCUMENT_ID,
   FLAG_PAUSE_ASSISTANT,
   FLAG_REDIRECT_PROTECTION,
+  FLAG_MODES,
 ] as const;
 
 // ---- Types and utility functions ----

--- a/src/config/flags.ts
+++ b/src/config/flags.ts
@@ -20,9 +20,6 @@ import {
 // ---- Active flags ----
 
 const flags: Config["flags"] = {
-  [FLAG_MODES]: [
-    { percentage: 100, filter: { version: "10.5.30" } },
-  ],
   [FLAG_ONBOARDING_SURVEY]: [
     { percentage: 20 },
   ],
@@ -72,6 +69,10 @@ const completedFlags: Config["flags"] = {
   ],
   // https://github.com/ghostery/ghostery-extension/pull/3380
   [FLAG_PAUSE_ASSISTANT]: [
+    { percentage: 100 },
+  ],
+  // https://github.com/ghostery/ghostery-extension/pull/3619
+  [FLAG_MODES]: [
     { percentage: 100 },
   ],
 };


### PR DESCRIPTION
Relates to https://github.com/ghostery/ghostery-extension/pull/3619

The `modes` flag has been fully rolled out at 100% for a while, so it no longer needs to live among the active flags in the config package.

This moves `FLAG_MODES` out of the `FLAGS` list and into `COMPLETED_FLAGS` in the config package, and moves its remote configuration entry from the active `flags` section to `completedFlags` in the extension config.